### PR TITLE
in Core.js - UNSAFE_willMount removed & put defaultSort to url

### DIFF
--- a/__tests__/SortFilter.spec.js
+++ b/__tests__/SortFilter.spec.js
@@ -49,7 +49,7 @@ test('Instantiate SortFilter component via mount', () => {
   expect(wrapper.find(Core).instance().element.current).toMatchSnapshot();
 })
 
-function Elements({ itemSelector }) {
+function Elements({ itemSelector, records }) {
   return records.map((record) => <Element key={record.id} record={record} itemSelector={itemSelector} />);
 }
 

--- a/src/SortFilter/Core.js
+++ b/src/SortFilter/Core.js
@@ -17,24 +17,10 @@ class Core extends Component {
     super(props);
     this.state = {
       // taxonomies: {},
-      taxonomiesBodyTypeNames: []
+      taxonomiesBodyTypeNames: Object.keys(this.props.taxonomies['Body Types'])
     };
     this.element = React.createRef();
     this.sizer = React.createRef();
-  }
-
-  UNSAFE_componentWillMount() {
-    /**
-     * Kick off the network request and update the state once it returns.
-     */
-    const { taxonomies } = this.props;
-    this._loadProps()
-      .then(() => {
-        this.setState({
-          // taxonomies,
-          taxonomiesBodyTypeNames: Object.keys(taxonomies['Body Types'])
-        });
-      });
   }
 
   componentDidMount() {
@@ -49,6 +35,7 @@ class Core extends Component {
       sizer: this.sizer.current,
       // initialSort: options
     });
+    putSearchParams(this.props.defaultSort);
     this.sortFromUrlSearch();
   }
 
@@ -142,18 +129,6 @@ class Core extends Component {
    */
   toggleSlide = () => {
     this.slider.classList.toggle('slider-closed');
-  }
-
-  /**
-   * Set delay
-   * @return {Promise<Object[]>} A promise which resolves with an array of objects.
-   */
-  _loadProps() {
-    return new Promise((resolve) => {
-      setTimeout(() => {
-        resolve(this.props);
-      }, 500);
-    });
   }
 
   render() {


### PR DESCRIPTION
UNSAFE_willMount() and _loadProps() are removed.

Because of defaultSort set to 'Cat', the 'City' was not appeared even the url search params are empty.
So, added putSearchParams() to componentDidMound().
It makes the url has the search params 'cat' automatically.
Then, even if you type in 'localhost:1234', the url automatically changes to 'localhost:1234/?cat'
Probably it isn't what you want.
Then you need to remove the whole defaultSort params from App.js to Core.js